### PR TITLE
Update steelseries_arctis_9.c

### DIFF
--- a/src/devices/steelseries_arctis_9.c
+++ b/src/devices/steelseries_arctis_9.c
@@ -146,7 +146,7 @@ int arctis_9_read_device_status(hid_device* device_handle, unsigned char* data_r
 {
     int r = 0;
 
-    unsigned char data_request[2] = { 0x20, 0x00 };
+    unsigned char data_request[2] = { 0x20, 0x20 };
     r                             = hid_write(device_handle, data_request, 2);
 
     if (r < 0)


### PR DESCRIPTION
Fixed data_request parameters for getting battery level for SteelSeries Arctic 9 on Win.
This patch helps to get the battery level from the CLI instead of using the SteelSeries GG app.
This patch solve the problem from Issue #182.

But there is one problem, when you unplug the headphones, it still shows the battery level as if they are plugged in.